### PR TITLE
Remplacement des email par un formulaire

### DIFF
--- a/content/actualites/lancement-dun-appel-à-manifestation-dintérêt-pour-participer-à-la-construction-dhistologe.md
+++ b/content/actualites/lancement-dun-appel-à-manifestation-dintérêt-pour-participer-à-la-construction-dhistologe.md
@@ -23,5 +23,5 @@ C'est un service qui a été lancé par l'Agglomération de Pau Béarn Pyrénée
 </a>
 
 <p class="mt-4">
-Contactez l'Incubateur des Territoires pour toute.s question.s : <strong><a href="mailto:contactincubateur@anct.gouv.fr">contactincubateur@anct.gouv.fr</a></strong>
+Contactez l'Incubateur des Territoires pour toute.s question.s : <strong><a href="/contact-territoires/">contact</a></strong>
 </p>

--- a/content/pages/collaborations.md
+++ b/content/pages/collaborations.md
@@ -4,4 +4,4 @@ id: collaborations
 ---
 L'Incubateur s'engage à faciliter le développement de briques numériques transverses essentielles à la transformation numérique des collectivités au-delà de ses programmes d'Investigations et Startups de Territoires.
 
-<a href="mailto:contactincubateur@anct.gouv.fr" class="cta">Contactez-nous pour plus d'infos →</a>
+<a href="/contact-territoires/" class="cta">Contactez-nous pour plus d'infos →</a>

--- a/content/pages/offres-aux-acteurs-publics-et-partenaires-des-collectivités.md
+++ b/content/pages/offres-aux-acteurs-publics-et-partenaires-des-collectivités.md
@@ -7,7 +7,7 @@ id: offres-partenaires
 
   <p>Il peut proposer un accompagnement méthodologique pour chercher, tester, développer et déployer une solution face à un problème. Il peut aider au lancement, au recrutement des équipes, à la formation, au suivi de l'impact, ou encore mettre à disposition des outils, etc.</p>
 
-  <a href="mailto:contactincubateur@anct.gouv.fr" class="cta shadow-yellow">Contactez-nous pour plus d'infos →</a>
+  <a href="/contact-territoires/" class="cta shadow-yellow">Contactez-nous pour plus d'infos →</a>
 
 </div>
 
@@ -42,5 +42,5 @@ Vous avez un projet qui pourrait être accompagné par l'Incubateur ? Quelques p
 > Au départ, l'équipe dédiée est composée d'un agent public et d'un.e développeur.se. accompagnés par un coach. Elle grossit au fur et à mesure de son évolution avec des chargés de déploiement, des juristes, des designers, etc. Cela conduit à créer une équipe dédiée avec un agent public référent - par opposition à une équipe projet.
 
 <div class="mt-8">
-  <a href="mailto:contactincubateur@anct.gouv.fr" class="cta shadow-yellow">Contactez-nous pour plus d'infos →</a>
+  <a href="/contact-territoires/" class="cta shadow-yellow">Contactez-nous pour plus d'infos →</a>
 </div>

--- a/content/pages/startups-de-territoires.md
+++ b/content/pages/startups-de-territoires.md
@@ -10,4 +10,4 @@ L'équipe autonome dédiée à la création de ce service, constituée d'experts
 
 Lorsqu'il s'agit d'une équipe dédiée à la création d'un service numérique dans le cadre d'une politique publique nationale pilotée par l'ANCT, on parle de **startup d'Etat**.
 
-<a href="mailto:contactincubateur@anct.gouv.fr" class="cta">Contactez-nous au sujet des Startups de Territoires →</a>
+<a href="/contact-territoires/" class="cta">Contactez-nous au sujet des Startups de Territoires →</a>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -15,7 +15,7 @@
       </div>
 
       <div class="incubateur-links inline-block mb-8 px-4 py-1 space-x-4 bg-gray-200 rounded-full">
-        <g-link to="mailto:contactincubateur@anct.gouv.fr">
+        <g-link to="/contact-territoires/">
             <font-awesome :icon="['fas', 'paper-plane']" transform="shrink-2"/> Contact
         </g-link>
         <g-link to="https://twitter.com/IncubateurT">


### PR DESCRIPTION
Remplacement des email par un formulaire de qualification disponible sur https://incubateur.anct.gouv.fr/contact-territoires/
![Capture d’écran 2021-03-09 à 15 59 59](https://user-images.githubusercontent.com/3593868/110490351-8235c380-80f0-11eb-9541-1fd1f9cb8734.png)
