### PR TITLE
Ajoute une offre de recrutement pour OpenFisca

### DIFF
--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -22,20 +22,22 @@ Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/2
 
 Nous cherchons deux personnes pour faire équipe et nous aider à atteindre les objectifs suivants :
 
-1. Au moins deux nouvelles collectivités territoriales Françaises mettent en ligne leurs prestations sociales locales.
-2. La communauté OpenFisca internationale actuelle bénéficie d’un accompagnement accéléré dans la réalisation de ses développements openfisca et de l’accès aux informations concernant le moteur et les évolutions du produit.
-3. De nouveaux contributeurs utilisent OpenFisca en production.
-4. La communauté OpenFisca France se structure autour d’une organisation pérenne (association, …) au modèle économique soutenable.
+- Au moins deux nouvelles collectivités territoriales Françaises mettent en ligne leurs prestations sociales locales.
+- La communauté OpenFisca internationale actuelle bénéficie d’un accompagnement accéléré dans la réalisation de ses développements openfisca et de l’accès aux informations concernant le moteur et les évolutions du produit.
+- De nouveaux contributeurs utilisent OpenFisca en production.
+- La communauté OpenFisca France se structure autour d’une organisation pérenne (association, …) au modèle économique soutenable.
+
 
 Il s’agit donc d’intervenir :
 
--   Sur une [base de code partagé](https://github.com/openfisca) en Python.
--   Sur une syntaxe basée sur du calcul vectoriel ([Numpy](https://numpy.org/devdocs/release/1.18.0-notes.html)).
--   Sur des sites web en [React](https://fr.reactjs.org) tels que [fr.openfisca.org](https://github.com/openfisca/fr.openfisca.org) et [l’explorateur openfisca-france](https://github.com/openfisca/legislation-explorer).
--   Sur de la [documentation](https://github.com/openfisca/openfisca-doc) en Markdown.
--   Sur la formalisation d'une gouvernance du produit en commun contributif pérenne.
--   En accompagnant des utilisateurs à l’utilisation du logiciel [via GitHub](https://github.com/openfisca/openfisca-france/issues). 
--   Ainsi que sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’usagers satisfaits !
+
+- Sur une [base de code partagé](https://github.com/openfisca) en Python.
+- Sur une syntaxe basée sur du calcul vectoriel ([Numpy](https://numpy.org/devdocs/release/1.18.0-notes.html)).
+- Sur des sites web en [React](https://fr.reactjs.org) tels que [fr.openfisca.org](https://github.com/openfisca/fr.openfisca.org) et [l’explorateur openfisca-france](https://github.com/openfisca/legislation-explorer).
+- Sur de la [documentation](https://github.com/openfisca/openfisca-doc) en Markdown.
+- Sur la formalisation d'une gouvernance du produit en commun contributif pérenne.
+- En accompagnant des utilisateurs à l’utilisation du logiciel [via GitHub](https://github.com/openfisca/openfisca-france/issues). 
+- Ainsi que sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’usagers satisfaits !
 
 
 Nous cherchons à créer une équipe multidisciplinaire : pas besoin d’être expert·e de tous ces sujets, nous nous répartirons la charge selon les intérêts et les compétences de chaque membre.

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -1,5 +1,5 @@
 ---
-role: Deux développeur·se·s Python / JS
+role: Développeur·se·s Python / JS
 contrat: Indépendant
 equipe: OpenFisca
 contact: contact@openfisca.org
@@ -16,7 +16,7 @@ Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/2
 
 ## Qui sommes-nous ?
 
-[OpenFisca](https://openfisca.org/fr/) est une communauté qui transcrit du code législatif en code logiciel. Nous construisons un moteur de calcul libre et ouvert qui permet de modéliser le système socio-fiscal de manière collaborative et transparente. Ce logiciel est utilisé par des chercheurs en économie, des services publics comme les simulateurs [Mes droits sociaux](http://mesdroitssociaux.gouv.fr) ou [leximpact](/startups/leximpact.html) et quelques services privés.
+[OpenFisca](https://openfisca.org/fr/) est une communauté qui transcrit du code législatif en code logiciel. Nous construisons un moteur de calcul libre et ouvert qui permet de modéliser le système socio-fiscal de manière collaborative et transparente. Ce logiciel est utilisé par des chercheurs en économie, des services publics comme les simulateurs [Mes droits sociaux](http://mesdroitssociaux.gouv.fr) ou [LexImpact](/startups/leximpact.html) et quelques services privés.
 
 ## Missions
 

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -11,7 +11,7 @@ OpenFisca à l'[Incubateur des Territoires](https://incubateur.anct.gouv.fr/a-pr
 
 Venez aider des personnes à accéder à leurs prestations sociales locales et apportez vos compétences pour rendre la législation calculable en outillant des services de simulation des effets de la loi !
 
-Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/28/equipes-autonomes/) qui développe OpenFisca.
+Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/28/equipes-autonomes/) qui développe OpenFisca au sein d'une famille d'incubateurs [beta.gouv.fr](https://beta.gouv.fr/approche/).
 
 ## Qui sommes-nous ?
 

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -60,7 +60,7 @@ Les plus :
 ## Modalités
 
 -   Poste ouvert pour un·e indépendant·e (en portage) de 3 mois minimum.
--   Télétravail partiel bienvenu, avec 2 jours toutes les deux semaines [à Paris](https://github.com/betagouv/beta.gouv.fr/wiki/Locaux) pour participer aux sessions communes de démonstration, rétrospective et planification… et pour avoir le sentiment de construire une équipe !
+-   Télétravail bienvenu, avec déplacements à prévoir [à Paris](https://goo.gl/maps/d9nzETo842qEcNxw9) pour participer aux sessions communes et pour avoir le sentiment de construire une équipe lorsque les conditions sanitaires le permettront !
 -   Temps partiel accepté (40 % minimum).
 -   Démarrage dès que possible.
 

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -1,9 +1,10 @@
 ---
-role: Développeur·se 
+role: Deux développeur·se·s Python / JS
 contrat: Indépendant
 equipe: OpenFisca
 contact: contact@openfisca.org
-post_ouvert: 2020-03-26
+poste_ouvert: 2021-03-29
+poste_ferme: 2021-05-01
 poste_pourvu: false
 ---
 

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -7,17 +7,21 @@ post_ouvert: 2020-03-26
 poste_pourvu: false
 ---
 
-OpenFisca cherche deux développeurs·ses intéressé·es par la collaboration et l’entraide.
+OpenFisca à l'Incubateur des Territoires cherche deux développeurs·ses intéressé·es par la collaboration et l’entraide.
 
-Venez aider les personnes à accéder à leurs prestations sociales locales et apportez vos compétences pour rendre la législation calculable en outillant d’autres devs !
+Venez aider des personnes à accéder à leurs prestations sociales locales et apportez vos compétences pour rendre la législation calculable en outillant des services de simulation des effets de la loi !
 
 Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/28/equipes-autonomes/) qui développe OpenFisca.
 
-[OpenFisca](https://openfisca.org/fr/) est une transcription du code législatif en code logiciel. Il s’agit d’un moteur de calcul libre et ouvert qui permet de modéliser le système socio-fiscal de manière collaborative et transparente. Ce logiciel est utilisé par des chercheurs en économie, des services publics comme les simulateurs [Mes droits sociaux](http://mesdroitssociaux.gouv.fr) ou [leximpact](/startups/leximpact.html) et quelques services privés.
+## Qui sommes-nous ?
 
-Nous cherchons une personne pour rejoindre notre équipe et nous aider à atteindre les objectifs suivants :
+[OpenFisca](https://openfisca.org/fr/) est une communauté qui transcrit du code législatif en code logiciel. Nous construisons un moteur de calcul libre et ouvert qui permet de modéliser le système socio-fiscal de manière collaborative et transparente. Ce logiciel est utilisé par des chercheurs en économie, des services publics comme les simulateurs [Mes droits sociaux](http://mesdroitssociaux.gouv.fr) ou [leximpact](/startups/leximpact.html) et quelques services privés.
 
-1. Au moins deux nouvelles collectivités territoriales mettent en ligne leurs prestations sociales locales.
+## Missions
+
+Nous cherchons deux personnes pour faire équipe et nous aider à atteindre les objectifs suivants :
+
+1. Au moins deux nouvelles collectivités territoriales Françaises mettent en ligne leurs prestations sociales locales.
 2. La communauté OpenFisca internationale actuelle bénéficie d’un accompagnement accéléré dans la réalisation de ses développements openfisca et de l’accès aux informations concernant le moteur.
 3. De nouveaux contributeurs utilisent OpenFisca en production.
 4. La communauté OpenFisca France se structure autour d’une organisation pérenne (association, …) au modèle économique soutenable.

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -22,7 +22,7 @@ Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/2
 Nous cherchons deux personnes pour faire équipe et nous aider à atteindre les objectifs suivants :
 
 1. Au moins deux nouvelles collectivités territoriales Françaises mettent en ligne leurs prestations sociales locales.
-2. La communauté OpenFisca internationale actuelle bénéficie d’un accompagnement accéléré dans la réalisation de ses développements openfisca et de l’accès aux informations concernant le moteur.
+2. La communauté OpenFisca internationale actuelle bénéficie d’un accompagnement accéléré dans la réalisation de ses développements openfisca et de l’accès aux informations concernant le moteur et les évolutions du produit.
 3. De nouveaux contributeurs utilisent OpenFisca en production.
 4. La communauté OpenFisca France se structure autour d’une organisation pérenne (association, …) au modèle économique soutenable.
 
@@ -32,8 +32,9 @@ Il s’agit donc d’intervenir :
 -   Sur une syntaxe basée sur du calcul vectoriel ([Numpy](https://numpy.org/devdocs/release/1.18.0-notes.html)).
 -   Sur des sites web en [React](https://fr.reactjs.org) tels que [fr.openfisca.org](https://github.com/openfisca/fr.openfisca.org) et [l’explorateur openfisca-france](https://github.com/openfisca/legislation-explorer).
 -   Sur de la [documentation](https://github.com/openfisca/openfisca-doc) en Markdown.
--   En accompagnant des utilisateurs à l’utilisation du logiciel [via GitHub](https://github.com/openfisca/openfisca-france/issues).
--   Sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’usagers satisfaits !
+-   Sur la formalisation d'une gouvernance du produit en commun contributif pérenne.
+-   En accompagnant des utilisateurs à l’utilisation du logiciel [via GitHub](https://github.com/openfisca/openfisca-france/issues). 
+-   Ainsi que sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’usagers satisfaits !
 
 
 Nous cherchons à créer une équipe multidisciplinaire : pas besoin d’être expert·e de tous ces sujets, nous nous répartirons la charge selon les intérêts et les compétences de chaque membre.

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -6,3 +6,58 @@ contact: contact@openfisca.org
 post_ouvert: 2020-03-26
 poste_pourvu: false
 ---
+
+OpenFisca cherche deux développeurs·ses intéressé·es par la collaboration et l’entraide.
+
+Venez aider les personnes à accéder à leurs prestations sociales locales et apportez vos compétences pour rendre la législation calculable en outillant d’autres devs !
+
+Vous rejoindrez l'[équipe autonome](https://blog.beta.gouv.fr/general/2016/11/28/equipes-autonomes/) qui développe OpenFisca.
+
+[OpenFisca](https://openfisca.org/fr/) est une transcription du code législatif en code logiciel. Il s’agit d’un moteur de calcul libre et ouvert qui permet de modéliser le système socio-fiscal de manière collaborative et transparente. Ce logiciel est utilisé par des chercheurs en économie, des services publics comme les simulateurs [Mes droits sociaux](http://mesdroitssociaux.gouv.fr) ou [leximpact](/startups/leximpact.html) et quelques services privés.
+
+Nous cherchons une personne pour rejoindre notre équipe et nous aider à atteindre les objectifs suivants :
+
+1. Au moins deux nouvelles collectivités territoriales mettent en ligne leurs prestations sociales locales.
+2. La communauté OpenFisca internationale actuelle bénéficie d’un accompagnement accéléré dans la réalisation de ses développements openfisca et de l’accès aux informations concernant le moteur.
+3. De nouveaux contributeurs utilisent OpenFisca en production.
+4. La communauté OpenFisca France se structure autour d’une organisation pérenne (association, …) au modèle économique soutenable.
+
+Il s’agit donc d’intervenir :
+
+-   Sur une [base de code](https://github.com/openfisca/openfisca-core) en Python.
+-   Sur une syntaxe basée sur du calcul vectoriel (Numpy).
+-   Sur des sites web en React tels que [fr.openfisca.org](https://github.com/openfisca/fr.openfisca.org) et [l’explorateur openfisca-france](https://github.com/openfisca/legislation-explorer).
+-   Sur de la [documentation](https://github.com/openfisca/openfisca-doc) en Markdown.
+-   En accompagnant des utilisateurs à l’utilisation du logiciel [via GitHub](https://github.com/openfisca/openfisca-france/issues).
+-   Sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’utilisateurs satisfaits !
+
+
+Nous cherchons à créer une équipe multidisciplinaire : pas besoin d’être expert·e de tous ces sujets, nous nous répartirons la charge selon les intérêts et les compétences de chaque membre.
+
+## Compétences et expérience
+
+-   Vous avez à cœur de rendre un service de qualité qui offre des opportunités de transformation des services publics dans le monde entier, y compris en outillant des réutilisateurs potentiellement peu à l'aise avec le développement logiciel.
+-   Vous êtes intéressé·e par les pratiques de contribution aux logiciels libres (ouverture par défaut, pull requests, peer reviews, …).
+-   Vous suivez les résultats obtenus sur la base de métriques d’impact.
+-   Vous êtes à l’aise avec le mode de fonctionnement des organisations horizontales, et avez à cœur de contribuer activement au sein de ce collectif.
+-   Vous n’avez pas peur de refactor une base de code endettée si vous êtes accompagné·e.
+-   Vous avez déjà une fois lamentablement échoué à réécrire une base de code from scratch.
+-   Les langues de travail sont l’anglais et le français. Un niveau d’expression professionnelle est demandé dans ces deux langues.
+
+Les plus : 
+
+-   Vous avez une connaissance de l’organisation des administrations publiques locales.
+-   Vous êtes à l’aise avec les aspects de contractualisation public et privé (partenariat, contrats, ou tout support commercial destiné à développer les usages des services numériques…).
+
+## Modalités
+
+-   Poste ouvert pour un·e indépendant·e (en portage) de 3 mois minimum.
+-   Télétravail partiel bienvenu, avec 2 jours toutes les deux semaines [à Paris](https://github.com/betagouv/beta.gouv.fr/wiki/Locaux) pour participer aux sessions communes de démonstration, rétrospective et planification… et pour avoir le sentiment de construire une équipe !
+-   Temps partiel accepté (40 % minimum).
+-   Démarrage dès que possible.
+
+## Candidater
+
+Racontez-nous pourquoi vous avez envie de nous rejoindre et envoyez-nous votre LinkedIn / CV et GitHub, le tout à `contact@openfisca.org`.
+
+À bientôt ! 😀

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -7,7 +7,7 @@ post_ouvert: 2020-03-26
 poste_pourvu: false
 ---
 
-OpenFisca à l'Incubateur des Territoires cherche deux développeurs·ses intéressé·es par la collaboration et l’entraide.
+OpenFisca à l'[Incubateur des Territoires](https://incubateur.anct.gouv.fr/a-propos/) cherche deux développeurs·ses intéressé·es par la collaboration et l’entraide.
 
 Venez aider des personnes à accéder à leurs prestations sociales locales et apportez vos compétences pour rendre la législation calculable en outillant des services de simulation des effets de la loi !
 
@@ -28,12 +28,12 @@ Nous cherchons deux personnes pour faire équipe et nous aider à atteindre les 
 
 Il s’agit donc d’intervenir :
 
--   Sur une [base de code](https://github.com/openfisca/openfisca-core) en Python.
--   Sur une syntaxe basée sur du calcul vectoriel (Numpy).
--   Sur des sites web en React tels que [fr.openfisca.org](https://github.com/openfisca/fr.openfisca.org) et [l’explorateur openfisca-france](https://github.com/openfisca/legislation-explorer).
+-   Sur une [base de code partagé](https://github.com/openfisca) en Python.
+-   Sur une syntaxe basée sur du calcul vectoriel ([Numpy](https://numpy.org/devdocs/release/1.18.0-notes.html)).
+-   Sur des sites web en [React](https://fr.reactjs.org) tels que [fr.openfisca.org](https://github.com/openfisca/fr.openfisca.org) et [l’explorateur openfisca-france](https://github.com/openfisca/legislation-explorer).
 -   Sur de la [documentation](https://github.com/openfisca/openfisca-doc) en Markdown.
 -   En accompagnant des utilisateurs à l’utilisation du logiciel [via GitHub](https://github.com/openfisca/openfisca-france/issues).
--   Sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’utilisateurs satisfaits !
+-   Sur tout ce que nous n’avons pas vu mais que vous nous ferez découvrir et qui peut nous rapprocher de nos objectifs communs et d’usagers satisfaits !
 
 
 Nous cherchons à créer une équipe multidisciplinaire : pas besoin d’être expert·e de tous ces sujets, nous nous répartirons la charge selon les intérêts et les compétences de chaque membre.
@@ -44,7 +44,7 @@ Nous cherchons à créer une équipe multidisciplinaire : pas besoin d’être e
 -   Vous êtes intéressé·e par les pratiques de contribution aux logiciels libres (ouverture par défaut, pull requests, peer reviews, …).
 -   Vous suivez les résultats obtenus sur la base de métriques d’impact.
 -   Vous êtes à l’aise avec le mode de fonctionnement des organisations horizontales, et avez à cœur de contribuer activement au sein de ce collectif.
--   Vous n’avez pas peur de refactor une base de code endettée si vous êtes accompagné·e.
+-   Vous n’avez pas peur de restructurer une base de code endettée si vous êtes accompagné·e.
 -   Vous avez déjà une fois lamentablement échoué à réécrire une base de code from scratch.
 -   Les langues de travail sont l’anglais et le français. Un niveau d’expression professionnelle est demandé dans ces deux langues.
 

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -60,7 +60,7 @@ Les plus :
 ## Modalités
 
 -   Poste ouvert pour un·e indépendant·e (en portage) de 3 mois minimum.
--   Télétravail bienvenu, avec déplacements à prévoir [à Paris](https://goo.gl/maps/d9nzETo842qEcNxw9) pour participer aux sessions communes et pour avoir le sentiment de construire une équipe lorsque les conditions sanitaires le permettront !
+-   Télétravail bienvenu, avec déplacements à prévoir [à Paris](https://goo.gl/maps/d9nzETo842qEcNxw9) pour participer aux sessions communes lorsque les conditions sanitaires le permettront !
 -   Temps partiel accepté (40 % minimum).
 -   Démarrage dès que possible.
 

--- a/content/jobs/2021-03-26-openfisca-developpement.md
+++ b/content/jobs/2021-03-26-openfisca-developpement.md
@@ -1,0 +1,8 @@
+---
+role: Développeur·se 
+contrat: Indépendant
+equipe: OpenFisca
+contact: contact@openfisca.org
+post_ouvert: 2020-03-26
+poste_pourvu: false
+---


### PR DESCRIPTION
Ajoute une offre pour deux recrutements OpenFisca.

Le descriptif définit le profils de deux développeurs comme moyenne de niveau d'expérience : 
* l'un.e pourra être expérimenté voire PO s'il a déjà connaissance du produit 
* et l'autre développeur.se pourra être plus junior
